### PR TITLE
Fix deprecated api `vim.register_keystroke_callback(...)`

### DIFF
--- a/lua/extmark-toy.lua
+++ b/lua/extmark-toy.lua
@@ -1,3 +1,5 @@
+local api = vim.api
+api.nvim_create_augroup('extmark-toy.nvim', { clear = true })
 local UPDATE_INTERVAL = 1000/60
 local HIDE_CURSOR = true
 
@@ -21,7 +23,14 @@ M.start = function(opts)
   end
 
   vim.o.eventignore = "all" -- TODO: undo this on_close
-  vim.cmd[[ au! WinLeave * :lua.require'extmark-toy'.stop() ]]
+  api.nvim_create_autocmd({ 'WinLeave' }, {
+    group = 'extmark-toy.nvim',
+    pattern = '*',
+    callback = function ()
+      require('extmark-toy').stop()
+    end
+  })
+
 
   -- TODO: calculate delta-time here and pass single value to all coroutines
 

--- a/lua/extmark-toy/spotlight.lua
+++ b/lua/extmark-toy/spotlight.lua
@@ -104,7 +104,7 @@ M.init = function(opts)
   api.nvim_win_set_option(context.floatwin.winid, "winblend", 3)
 
   -- register color change key
-  M.nsid = vim.register_keystroke_callback(keystroke_callback, context.nsid)
+  M.nsid = vim.on_key(keystroke_callback, context.nsid)
 
   -- create exmarks and create map of objects, each extmark_obj containing a reference to the extmarkID, ascii character, it's position and brightness
   -- -----------------
@@ -229,7 +229,7 @@ end
 -- cleanup effect specific stuff
 M.on_close = function()
   -- unregister key callback
-  vim.register_keystroke_callback(nil, M.context.nsid)
+  vim.on_key(function () end, M.context.nsid)
   -- clear extmarks
   api.nvim_buf_clear_namespace(M.context.floatwin.bufid, M.context.nsid, 0, -1)
   -- remove logo buffer and its floating window

--- a/lua/extmark-toy/utils.lua
+++ b/lua/extmark-toy/utils.lua
@@ -39,13 +39,12 @@ function M.create_window(width, height, row, col)
   }
 
   local bufid = api.nvim_create_buf(false, true)
-  api.nvim_buf_set_keymap(
-    bufid,
-    "n",
-    "q",
-    "<Cmd>lua require'extmark-toy'.stop()<CR>",
-    { noremap = true, silent = true }
-  )
+  vim.keymap.set('n', 'q', function ()
+    require('extmark-toy').stop()
+  end, {
+    buffer = bufid,
+    noremap = true, silent = true,
+  })
 
   local winid = api.nvim_open_win(bufid, true, opts) -- enter window = true to set bufferlocal autocommands
 

--- a/lua/extmark-toy/utils.lua
+++ b/lua/extmark-toy/utils.lua
@@ -39,12 +39,11 @@ function M.create_window(width, height, row, col)
   }
 
   local bufid = api.nvim_create_buf(false, true)
-  vim.keymap.set('n', 'q', function ()
-    require('extmark-toy').stop()
-  end, {
-    buffer = bufid,
-    noremap = true, silent = true,
-  })
+  vim.keymap.set('n', 'q', function () require('extmark-toy').stop() end, { buffer = bufid, noremap = true, silent = true, })
+  vim.keymap.set('n', 'h', function () require('extmark-toy').stop() end, { buffer = bufid, noremap = true, silent = true, })
+  vim.keymap.set('n', 'j', function () require('extmark-toy').stop() end, { buffer = bufid, noremap = true, silent = true, })
+  vim.keymap.set('n', 'k', function () require('extmark-toy').stop() end, { buffer = bufid, noremap = true, silent = true, })
+  vim.keymap.set('n', 'l', function () require('extmark-toy').stop() end, { buffer = bufid, noremap = true, silent = true, })
 
   local winid = api.nvim_open_win(bufid, true, opts) -- enter window = true to set bufferlocal autocommands
 


### PR DESCRIPTION
Logs:

- Running on nightly [neovim/neovim@148499](https://github.com/neovim/neovim/commit/1484995a1e5ab29010878fa5ee27c935fec6522f) caused a segment fault.
- Running on nightly [neovim/neovim@99cf111](https://github.com/neovim/neovim/commit/1484995a1e5ab29010878fa5ee27c935fec6522f) can run the animation without error, but it caused an error when calling after the animation `Noice history`.